### PR TITLE
Allow tokenize to deal with unicode characters.

### DIFF
--- a/tokenize.go
+++ b/tokenize.go
@@ -1,33 +1,36 @@
 package matcher
 
-import ()
+import (
+	"unicode"
+)
 
 // Tokenize func
 func Tokenize(input string) (tokens []string) {
-	token := []int32{}
+	runeInput := []rune(input)
+
+	token := []rune{}
 	isQuote := false
-	for i, c := range input {
-		if c == 34 || c == 39 { // quotes
+	for i, r := range runeInput {
+		if r == rune('\'') || r == rune('"') { // quotes
 			isQuote = !isQuote
 		}
 		if isQuote {
-			if c != 34 && c != 39 {
-				token = append(token, c)
+			if r != rune('\'') && r != rune('"') {
+				token = append(token, r)
 			}
 		} else {
-			switch c {
-			case 9, 10, 11, 12, 13, 32:
+			if unicode.IsSpace(r) {
 				if len(token) > 0 {
 					tokens = append(tokens, string(token))
 				}
-				token = []int32{}
-			default:
-				if c != 34 && c != 39 {
-					token = append(token, c)
+				token = []rune{}
+			} else {
+				if r != rune('\'') && r != rune('"') {
+					token = append(token, r)
 				}
 			}
 		}
-		if i == len(input)-1 && len(token) > 0 {
+		if i == len(runeInput)-1 && len(token) > 0 {
 			tokens = append(tokens, string(token))
 		}
 	}

--- a/tokenize_test.go
+++ b/tokenize_test.go
@@ -1,6 +1,7 @@
 package matcher
 
 import (
+	"html"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,4 +45,19 @@ func TestTokenizeFlags(t *testing.T) {
 	assert.Equal(t, tokens[3], "--skip", "they should be equal")
 	assert.Equal(t, tokens[4], "-x", "they should be equal")
 	assert.Equal(t, len(tokens), 5, "they should be equal")
+}
+
+func TestTokenizeUnicodeWhitespace(t *testing.T) {
+	tokens := Tokenize("run" + html.UnescapeString("&#160;") + "far away")
+	assert.Equal(t, tokens[0], "run", "they should be equal")
+	assert.Equal(t, tokens[1], "far", "they should be equal")
+	assert.Equal(t, tokens[2], "away", "they should be equal")
+}
+
+func TestTokenizeUnicodeTokens(t *testing.T) {
+	tokens := Tokenize("🚀🐢 far 🌐🏳️‍🌈 \"🍻 . 🔥\"")
+	assert.Equal(t, tokens[0], "🚀🐢", "they should be equal")
+	assert.Equal(t, tokens[1], "far", "they should be equal")
+	assert.Equal(t, tokens[2], "🌐🏳️‍🌈", "they should be equal")
+	assert.Equal(t, tokens[3], "🍻 . 🔥", "they should be equal")
 }


### PR DESCRIPTION
The matcher library `Tokenize` function was previously based on iterating strings and matching on specific ASCII character codes. This can break in situations where unicode characters are used, specifically, if tokens are separated by unicode whitespace (in my particular case, the [NO-BREAK SPACE](https://www.compart.com/en/unicode/U+00A0)). 

Switch the tokenize library to operate over runes instead of characters, and split tokens on anything that matches the Go library function `unicode.IsSpace`, instead of the predefined ASCII character list that was previously used.